### PR TITLE
Splits the Monte Carlo logic to update parameters

### DIFF
--- a/src/monte_carlo.jl
+++ b/src/monte_carlo.jl
@@ -338,7 +338,7 @@ function load_fair_monte_carlo(n_samples::Int;
     #Calculate thermal decay factors, defined as exp(-1/d).
     thermal_decay_factors = exp.(-1.0 ./ Array(thermal_params[:,[:d1,:d2,:d3]]))
 
-    function prepare_instance(fair_instance::ModelInstance, i::Int64)
+    function prepare_instance(fair_instance::Mimi.ModelInstance, i::Int64)
         # ---- Global Temperature Anomaly ---- #
         update_param!(fair_instance, :temperature, :decay_factor, thermal_decay_factors[i,:])
         update_param!(fair_instance, :temperature, :q, Array(thermal_params[i,[:q1,:q2,:q3]]))

--- a/src/monte_carlo.jl
+++ b/src/monte_carlo.jl
@@ -7,12 +7,12 @@
 #              then creates a second function, "fair_monte_carlo" that performs the actual analysis. This function returns
 #              a dictionary with temperature, atmospheric co2, ch4, and n2o, and radiative forcing. Adding other outputs
 #              is doable please add an Issue on Github if you would like this to be done. This returned function can optionally take
-#              a vector of vectors to force co2, ch4, and n2o emissions trajectories for the `n_samples` runs, providing 
-#              these in the native MimiFAIRv2 emissions units, using optional arguments `co2_em_vals`, `ch4_em_vals`, and `n2o_em_vals` 
-#              respectively. 
+#              a vector of vectors to force co2, ch4, and n2o emissions trajectories for the `n_samples` runs, providing
+#              these in the native MimiFAIRv2 emissions units, using optional arguments `co2_em_vals`, `ch4_em_vals`, and `n2o_em_vals`
+#              respectively.
 #
-#               The required constrained parameter files are uploaded to Zenodo with the citation Frank Errickson, 
-#               & Lisa Rennels. (2021). MimiFAIRV2 Large Data File Storage (0.1.0-DEV) [Data set]. Zenodo. 
+#               The required constrained parameter files are uploaded to Zenodo with the citation Frank Errickson,
+#               & Lisa Rennels. (2021). MimiFAIRV2 Large Data File Storage (0.1.0-DEV) [Data set]. Zenodo.
 #               https://doi.org/10.5281/zenodo.5513221
 #
 # Function Arguments:
@@ -22,11 +22,11 @@
 #       start_year:         First year to run the model (note, Mimi-FAIR requires user-supplied initial conditions if not starting in 1750 so this is not yet supported for a year other than 1750).
 #       end_year:           Final year to run the model.
 #       data_dir:           Location of the data files
-#       sample_id_subset:   IDs of the subset of samples to use from original constrained parameter values (each ID between 1 and 93,995 
-#                           inclusive). If this argument is set, it will be used instead of the step to create n random indices. The length 
+#       sample_id_subset:   IDs of the subset of samples to use from original constrained parameter values (each ID between 1 and 93,995
+#                           inclusive). If this argument is set, it will be used instead of the step to create n random indices. The length
 #                           should match n_samples, and if it is longer we will choose the first 1:n.
 #       delete_downloaded_data: Boolean (defaulting to false) to recursively delete all downloaded large data files of constrained parameters
-#                               at the end of the script.  Should be set to `false` if one will be running this several times and want to avoid 
+#                               at the end of the script.  Should be set to `false` if one will be running this several times and want to avoid
 #                               re-downloading each time.
 #
 #----------------------------------------------------------------------------------------------------------------------
@@ -34,11 +34,10 @@
 # Load packages.
 using CSVFiles, DataFrames, Mimi, MimiFAIRv2, StatsBase, Downloads, Query
 
-
-function create_fair_monte_carlo(n_samples::Int; 
-                                emissions_scenario::String="ssp585", 
-                                start_year::Int=1750, 
-                                end_year::Int=2300, 
+function create_fair_monte_carlo(n_samples::Int;
+                                emissions_scenario::String="ssp585",
+                                start_year::Int=1750,
+                                end_year::Int=2300,
                                 data_dir::String = joinpath(@__DIR__, "..", "data", "large_constrained_parameter_files"),
                                 sample_id_subset::Union{Vector, Nothing} = nothing,
                                 delete_downloaded_data::Bool = true
@@ -46,18 +45,103 @@ function create_fair_monte_carlo(n_samples::Int;
 
     if start_year !== 1750
         error("FAIRv2 model monte carlo simulation should not be set to start with a year differing from 1750 as initial conditions are not calibrated for a different start year!")
-    end 
-                            
-    # Load constrained FAIR parameters from Leach et al. (2021) 
-    
+    end
+
+    prepare_instance = load_fair_monte_carlo(n_samples; start_year=start_year, end_year=end_year,
+                                             data_dir=data_dir, sample_id_subset=sample_id_subset,
+                                             delete_downloaded_data=delete_downloaded_data)
+
+    # Create a function to carry out the actual Monte Carlo analysis (passing in sampled constrained parameter values).
+    function fair_monte_carlo(  ;co2_em_vals::Union{Nothing, Vector{Vector{T1}}}  = nothing,
+                                n2o_em_vals::Union{Nothing, Vector{Vector{T2}}} = nothing,
+                                ch4_em_vals::Union{Nothing, Vector{Vector{T3}}} = nothing) where {T1, T2, T3}
+        # check dimensions
+        if !isnothing(co2_em_vals)
+            if length(co2_em_vals) !== n_samples || length(co2_em_vals[1]) !== (end_year - start_year + 1)
+                error("The provided co2_em_vals must be a vector with n_samples ($n_samples) elements, each of which is a vector spanning the full time of the model being run ($start_year to $end_year). Provided co2_em_vals has $(length(co2_em_vals)), with first element of length $(length(co2_em_vals[1]))")
+            end
+        end
+
+        if !isnothing(ch4_em_vals)
+            if length(ch4_em_vals) !== n_samples || length(ch4_em_vals[1]) !== (end_year - start_year + 1)
+                error("The provided ch4_em_vals must be a vector with n_samples ($n_samples) elements, each of which is a vector spanning the full time of the model being run ($start_year to $end_year). Provided co2_em_vals has $(length(ch4_em_vals)), with first element of length $(length(ch4_em_vals[1]))")
+            end
+        end
+
+        if !isnothing(n2o_em_vals)
+            if length(n2o_em_vals) !== n_samples || length(n2o_em_vals[1]) !== (end_year - start_year + 1)
+                error("The provided n2o_em_vals must be a vector with n_samples ($n_samples) elements, each of which is a vector spanning the full time of the model being run ($start_year to $end_year). Provided co2_em_vals has $(length(n2o_em_vals)), with first element of length $(length(n2o_em_vals[1]))")
+            end
+        end
+
+        # Initialize an array to store FAIR temperature projections.
+        temperatures = zeros(length(start_year:end_year), n_samples)  # Global mean surface temperature anomaly (K)
+        rf = zeros(length(start_year:end_year), n_samples)            # Total radiative forcing, with individual components scaled by their respective efficacy (Wm⁻²)
+        co2 = zeros(length(start_year:end_year), n_samples)           # Total atmospheric carbon dioxide concentrations (ppm).
+        ch4 = zeros(length(start_year:end_year), n_samples)           # Total atmospheric methane concentrations (ppb)
+        n2o = zeros(length(start_year:end_year), n_samples)           # Total atmospheric nitrous oxide concentrations (ppb).
+
+        # Load an instance of FAIR with user-specificed settings.
+        fair_model = MimiFAIRv2.get_model(emissions_forcing_scenario=emissions_scenario, start_year=start_year, end_year=end_year)
+
+        # Create a model instance to speed things up.
+        fair_instance = Mimi.build(fair_model)
+
+        for i = 1:n_samples
+
+            # ---- Emissions Trajectories ---- #
+            if !(isnothing(co2_em_vals))
+                update_param!(fair_instance, :co2_cycle, :E_co2, co2_em_vals[i])
+            end
+
+            if !(isnothing(n2o_em_vals))
+                update_param!(fair_instance, :n2o_cycle, :E_n2o, n2o_em_vals[i])
+            end
+
+            if !(isnothing(ch4_em_vals))
+                update_param!(fair_instance, :ch4_cycle, :E_ch4, ch4_em_vals[i])
+            end
+
+            prepare_instance(fair_instance, i)
+
+            # Run model.
+            run(fair_instance)
+
+            # Store projections.
+            temperatures[:,i] = fair_instance[:temperature, :T] # Global mean surface temperature anomaly (K)
+            rf[:, i] = fair_instance[:radiative_forcing, :total_RF] # Total radiative forcing, with individual components scaled by their respective efficacy (Wm⁻²)
+            co2[:, i] = fair_instance[:co2_cycle, :co2]  # Total atmospheric carbon dioxide concentrations (ppm).
+            ch4[:, i] = fair_instance[:ch4_cycle, :ch4]  # Total atmospheric methane concentrations (ppb)
+            n2o[:, i] = fair_instance[:n2o_cycle, :n2o]  # Total atmospheric nitrous oxide concentrations (ppb)
+
+        end
+
+        # Return temperature and radiative forcing
+        return Dict(:temperatures => temperatures, :rf => rf, :co2 => co2, :ch4 => ch4, :n2o => n2o)
+    end
+
+    # Return 'fair_monte_carlo' function.
+    return fair_monte_carlo
+end
+
+function load_fair_monte_carlo(n_samples::Int;
+                               start_year::Int=1750,
+                               end_year::Int=2300,
+                               data_dir::String = joinpath(@__DIR__, "..", "data", "large_constrained_parameter_files"),
+                               sample_id_subset::Union{Vector, Nothing} = nothing,
+                               delete_downloaded_data::Bool = true
+                               )
+
+    # Load constrained FAIR parameters from Leach et al. (2021)
+
     # Full files are pulled down via zenodo links to a local directory if they do
     # not already exist in the repository relative path
     isdir(data_dir) || mkpath(data_dir)
     _download_paths = Dict(
-                :julia_constrained_thermal_parameters_average_probs => "https://zenodo.org/record/5513221/files/julia_constrained_thermal_parameters_average_probs.csv?download=1", 
+                :julia_constrained_thermal_parameters_average_probs => "https://zenodo.org/record/5513221/files/julia_constrained_thermal_parameters_average_probs.csv?download=1",
                 :julia_constrained_gas_cycle_parameters_average_probs => "https://zenodo.org/record/5513221/files/julia_constrained_gas_cycle_parameters_average_probs.csv?download=1",
-                :julia_constrained_indirect_forcing_parameters_average_probs => "https://zenodo.org/record/5513221/files/julia_constrained_indirect_forcing_parameters_average_probs.csv?download=1", 
-                :julia_constrained_exogenous_forcing_parameters_average_probs => "https://zenodo.org/record/5513221/files/julia_constrained_exogenous_forcing_parameters_average_probs.csv?download=1", 
+                :julia_constrained_indirect_forcing_parameters_average_probs => "https://zenodo.org/record/5513221/files/julia_constrained_indirect_forcing_parameters_average_probs.csv?download=1",
+                :julia_constrained_exogenous_forcing_parameters_average_probs => "https://zenodo.org/record/5513221/files/julia_constrained_exogenous_forcing_parameters_average_probs.csv?download=1",
     )
 
     for (k, v) in _download_paths
@@ -75,7 +159,7 @@ function create_fair_monte_carlo(n_samples::Int;
     thermal_params = load(joinpath(data_dir, "julia_constrained_thermal_parameters_average_probs.csv")) |> @select(:sample_id) |> DataFrame
 
     if isnothing(sample_id_subset)
-        rand_indices     = sort(sample(1:93995, n_samples, replace=false)) 
+        rand_indices     = sort(sample(1:93995, n_samples, replace=false))
         sample_id_subset = thermal_params[rand_indices, :sample_id]
     # Do some checks on the provided sample id subset
     else
@@ -197,7 +281,7 @@ function create_fair_monte_carlo(n_samples::Int;
         montreal_rT[:,i]          = montreal_gas_p[indices.montreal_gas_p_rows[i], :rT]
         montreal_rA[:,i]          = montreal_gas_p[indices.montreal_gas_p_rows[i], :rA]
         montreal_pi_conc[:,i]     = montreal_gas_p[indices.montreal_gas_p_rows[i], :PI_conc]
-        
+
         # Flourinated gases.
         flourinated_a[:,:,i]      = flourinated_gas_p[indices.flourinated_gas_p_rows[i], [:a1,:a2,:a3,:a4]]|> Matrix
         flourinated_τ[:,:,i]      = flourinated_gas_p[indices.flourinated_gas_p_rows[i], [:tau1,:tau2,:tau3,:tau4]]|> Matrix
@@ -254,202 +338,136 @@ function create_fair_monte_carlo(n_samples::Int;
     #Calculate thermal decay factors, defined as exp(-1/d).
     thermal_decay_factors = exp.(-1.0 ./ Array(thermal_params[:,[:d1,:d2,:d3]]))
 
-    # Create a function to carry out the actual Monte Carlo analysis (passing in sampled constrained parameter values).
-    function fair_monte_carlo(  ;co2_em_vals::Union{Nothing, Vector{Vector{T1}}}  = nothing,
-                                n2o_em_vals::Union{Nothing, Vector{Vector{T2}}} = nothing,
-                                ch4_em_vals::Union{Nothing, Vector{Vector{T3}}} = nothing) where {T1, T2, T3}
+    function prepare_instance(fair_instance::ModelInstance, i::Int64)
+        # ---- Global Temperature Anomaly ---- #
+        update_param!(fair_instance, :temperature, :decay_factor, thermal_decay_factors[i,:])
+        update_param!(fair_instance, :temperature, :q, Array(thermal_params[i,[:q1,:q2,:q3]]))
+        #update_param!(fair_instance, :temperature, :Tj_0, vec(Array(init_thermal_vals[:,[:thermal_box_1,:thermal_box_2,:thermal_box_3]])))
+        #update_param!(fair_instance, :temperature, :T_0, init_thermal_vals.global_temp_anomaly[1])
 
-        # check dimensions
-        if !isnothing(co2_em_vals)
-            if length(co2_em_vals) !== n_samples || length(co2_em_vals[1]) !== (end_year - start_year + 1)
-                error("The provided co2_em_vals must be a vector with n_samples ($n_samples) elements, each of which is a vector spanning the full time of the model being run ($start_year to $end_year). Provided co2_em_vals has $(length(co2_em_vals)), with first element of length $(length(co2_em_vals[1]))")
-            end
-        end
+        # ---- Carbon Cycle ---- #
+        update_param!(fair_instance, :co2_cycle, :r0_co2, co2_p.r0[i])
+        update_param!(fair_instance, :co2_cycle, :rU_co2, co2_p.rC[i])
+        update_param!(fair_instance, :co2_cycle, :rT_co2, co2_p.rT[i])
+        update_param!(fair_instance, :co2_cycle, :rA_co2, co2_p.rA[i])
+        update_param!(fair_instance, :co2_cycle, :g0_co2, g0_co2[i])
+        update_param!(fair_instance, :co2_cycle, :g1_co2, g1_co2[i])
+        update_param!(fair_instance, :co2_cycle, :a_co2,  co2_a[i,:])
+        update_param!(fair_instance, :co2_cycle, :τ_co2,  co2_τ[i,:])
+        # update_param!(fair_instance, :co2_cycle, :co2_0, co2_init.concentration[1])
+        # update_param!(fair_instance, :co2_cycle, :GU_co2_0, co2_init.cumulative_uptake[1])
+        # update_param!(fair_instance, :co2_cycle, :R0_co2, vec(Array(co2_init[:,[:pool1,:pool2,:pool3,:pool4]])))
 
-        if !isnothing(ch4_em_vals)
-            if length(ch4_em_vals) !== n_samples || length(ch4_em_vals[1]) !== (end_year - start_year + 1)
-                error("The provided ch4_em_vals must be a vector with n_samples ($n_samples) elements, each of which is a vector spanning the full time of the model being run ($start_year to $end_year). Provided co2_em_vals has $(length(ch4_em_vals)), with first element of length $(length(ch4_em_vals[1]))")
-            end
-        end
+        # ---- Methane Cycle ---- #
+        update_param!(fair_instance, :ch4_cycle, :r0_ch4, ch4_p.r0[i])
+        update_param!(fair_instance, :ch4_cycle, :rU_ch4, ch4_p.rC[i])
+        update_param!(fair_instance, :ch4_cycle, :rT_ch4, ch4_p.rT[i])
+        update_param!(fair_instance, :ch4_cycle, :rA_ch4, ch4_p.rA[i])
+        update_param!(fair_instance, :ch4_cycle, :g0_ch4, g0_ch4[i])
+        update_param!(fair_instance, :ch4_cycle, :g1_ch4, g1_ch4[i])
+        update_param!(fair_instance, :ch4_cycle, :a_ch4,  ch4_a[i,:])
+        update_param!(fair_instance, :ch4_cycle, :τ_ch4,  ch4_τ[i,:])
+        # update_param!(fair_instance, :ch4_cycle, :ch4_0, ch4_init.concentration[1])
+        # update_param!(fair_instance, :ch4_cycle, :GU_ch4_0, ch4_init.cumulative_uptake[1])
+        # update_param!(fair_instance, :ch4_cycle, :R0_ch4, vec(Array(ch4_init[:,[:pool1,:pool2,:pool3,:pool4]])))
 
-        if !isnothing(n2o_em_vals)
-            if length(n2o_em_vals) !== n_samples || length(n2o_em_vals[1]) !== (end_year - start_year + 1)
-                error("The provided n2o_em_vals must be a vector with n_samples ($n_samples) elements, each of which is a vector spanning the full time of the model being run ($start_year to $end_year). Provided co2_em_vals has $(length(n2o_em_vals)), with first element of length $(length(n2o_em_vals[1]))")
-            end
-        end
-        
-        # Initialize an array to store FAIR temperature projections.
-        temperatures = zeros(length(start_year:end_year), n_samples)  # Global mean surface temperature anomaly (K)
-        rf = zeros(length(start_year:end_year), n_samples)            # Total radiative forcing, with individual components scaled by their respective efficacy (Wm⁻²)
-        co2 = zeros(length(start_year:end_year), n_samples)           # Total atmospheric carbon dioxide concentrations (ppm).
-        ch4 = zeros(length(start_year:end_year), n_samples)           # Total atmospheric methane concentrations (ppb)
-        n2o = zeros(length(start_year:end_year), n_samples)           # Total atmospheric nitrous oxide concentrations (ppb).
+        # ---- Nitrous Oxide Cycle ---- #
+        update_param!(fair_instance, :n2o_cycle, :r0_n2o, n2o_p.r0[i])
+        update_param!(fair_instance, :n2o_cycle, :rU_n2o, n2o_p.rC[i])
+        update_param!(fair_instance, :n2o_cycle, :rT_n2o, n2o_p.rT[i])
+        update_param!(fair_instance, :n2o_cycle, :rA_n2o, n2o_p.rA[i])
+        update_param!(fair_instance, :n2o_cycle, :g0_n2o, g0_n2o[i])
+        update_param!(fair_instance, :n2o_cycle, :g1_n2o, g1_n2o[i])
+        update_param!(fair_instance, :n2o_cycle, :a_n2o,  n2o_a[i,:])
+        update_param!(fair_instance, :n2o_cycle, :τ_n2o,  n2o_τ[i,:])
+        # update_param!(fair_instance, :n2o_cycle, :n2o_0, n2o_init.concentration[1])
+        # update_param!(fair_instance, :n2o_cycle, :GU_n2o_0, n2o_init.cumulative_uptake[1])
+        # update_param!(fair_instance, :n2o_cycle, :R0_n2o, vec(Array(n2o_init[:,[:pool1,:pool2,:pool3,:pool4]])))
 
-        # Load an instance of FAIR with user-specificed settings.
-        fair_model = MimiFAIRv2.get_model(emissions_forcing_scenario=emissions_scenario, start_year=start_year, end_year=end_year)
+        # ---- Flourinated Gas Cycles ---- #
+        update_param!(fair_instance, :flourinated_cycles, :r0_flourinated, flourinated_r0[:,i])
+        update_param!(fair_instance, :flourinated_cycles, :rU_flourinated, flourinated_rC[:,i])
+        update_param!(fair_instance, :flourinated_cycles, :rT_flourinated, flourinated_rT[:,i])
+        update_param!(fair_instance, :flourinated_cycles, :rA_flourinated, flourinated_rA[:,i])
+        update_param!(fair_instance, :flourinated_cycles, :g0_flourinated, flourinated_g0[:,i])
+        update_param!(fair_instance, :flourinated_cycles, :g1_flourinated, flourinated_g1[:,i])
+        update_param!(fair_instance, :flourinated_cycles, :a_flourinated,  flourinated_a[:,:,i])
+        update_param!(fair_instance, :flourinated_cycles, :τ_flourinated,  flourinated_τ[:,:,i])
+        # update_param!(fair_instance, :flourinated_cycles, :flourinated_0, flourinated_init[:, :concentration])
+        # update_param!(fair_instance, :flourinated_cycles, :GU_flourinated_0, flourinated_init[:, :cumulative_uptake])
+        # update_param!(fair_instance, :flourinated_cycles, :R0_flourinated, Array(flourinated_init[:,[:pool1,:pool2,:pool3,:pool4]]))
 
-        # Create a model instance to speed things up.
-        fair_instance = Mimi.build(fair_model)
+        # ---- Montreal Protocol Gas Cycles ---- #
+        update_param!(fair_instance, :montreal_cycles, :r0_montreal, montreal_r0[:,i])
+        update_param!(fair_instance, :montreal_cycles, :rU_montreal, montreal_rC[:,i])
+        update_param!(fair_instance, :montreal_cycles, :rT_montreal, montreal_rT[:,i])
+        update_param!(fair_instance, :montreal_cycles, :rA_montreal, montreal_rA[:,i])
+        update_param!(fair_instance, :montreal_cycles, :g0_montreal, montreal_g0[:,i])
+        update_param!(fair_instance, :montreal_cycles, :g1_montreal, montreal_g1[:,i])
+        update_param!(fair_instance, :montreal_cycles, :a_montreal,  montreal_a[:,:,i])
+        update_param!(fair_instance, :montreal_cycles, :τ_montreal,  montreal_τ[:,:,i])
+        # update_param!(fair_instance, :montreal_cycles, :montreal_0, montreal_init[:, :concentration])
+        # update_param!(fair_instance, :montreal_cycles, :GU_montreal_0, montreal_init[:, :cumulative_uptake])
+        # update_param!(fair_instance, :montreal_cycles, :R0_montreal, Array(montreal_init[:,[:pool1,:pool2,:pool3,:pool4]]))
 
-        for i = 1:n_samples
-            
-            # ---- Emissions Trajectories ---- #
-            if !(isnothing(co2_em_vals))
-                update_param!(fair_instance, :co2_cycle, :E_co2, co2_em_vals[i])
-            end
+        # ---- Tropospheric Ozone Precursors, Aerosols, & Reactive Gas Cycles (Aerosol+) ---- #
+        update_param!(fair_instance, :aerosol_plus_cycles, :r0_aerosol_plus, aerosol_plus_r0[:,i])
+        update_param!(fair_instance, :aerosol_plus_cycles, :rU_aerosol_plus, aerosol_plus_rC[:,i])
+        update_param!(fair_instance, :aerosol_plus_cycles, :rT_aerosol_plus, aerosol_plus_rT[:,i])
+        update_param!(fair_instance, :aerosol_plus_cycles, :rA_aerosol_plus, aerosol_plus_rA[:,i])
+        update_param!(fair_instance, :aerosol_plus_cycles, :g0_aerosol_plus, aerosol_plus_g0[:,i])
+        update_param!(fair_instance, :aerosol_plus_cycles, :g1_aerosol_plus, aerosol_plus_g1[:,i])
+        update_param!(fair_instance, :aerosol_plus_cycles, :a_aerosol_plus,  aerosol_plus_a[:,:,i])
+        update_param!(fair_instance, :aerosol_plus_cycles, :τ_aerosol_plus,  aerosol_plus_τ[:,:,i])
+        # update_param!(fair_instance, :aerosol_plus_cycles, :aerosol_plus_0, aerosol_plus_init[:, :concentration])
+        # update_param!(fair_instance, :aerosol_plus_cycles, :GU_aerosol_plus_0, aerosol_plus_init[:, :cumulative_uptake])
+        # update_param!(fair_instance, :aerosol_plus_cycles, :R0_aerosol_plus, Array(aerosol_plus_init[:,[:pool1,:pool2,:pool3,:pool4]]))
 
-            if !(isnothing(n2o_em_vals))
-                update_param!(fair_instance, :n2o_cycle, :E_n2o, n2o_em_vals[i])
-            end
-            
-            if !(isnothing(ch4_em_vals))
-                update_param!(fair_instance, :ch4_cycle, :E_ch4, ch4_em_vals[i])
-            end
+        # ---- Radiative Forcing ---- #
+        update_param!(fair_instance, :radiative_forcing, :co2_f, co2_f[i,:])
+        update_param!(fair_instance, :radiative_forcing, :ch4_f, ch4_f[i,:])
+        update_param!(fair_instance, :radiative_forcing, :ch4_o3_f, ch4_o3_f[i,:])
+        update_param!(fair_instance, :radiative_forcing, :ch4_h2o_f, ch4_h2o_f[i,:])
+        update_param!(fair_instance, :radiative_forcing, :n2o_f, n2o_f[i,:])
+        update_param!(fair_instance, :radiative_forcing, :n2o_o3_f, n2o_o3_f[i,:])
+        update_param!(fair_instance, :radiative_forcing, :montreal_f, montreal_f[:,:,i])
+        update_param!(fair_instance, :radiative_forcing, :montreal_ind_f, montreal_ind_f[:,:,i])
+        update_param!(fair_instance, :radiative_forcing, :flourinated_f,flourinated_f[:,:,i])
+        update_param!(fair_instance, :radiative_forcing, :bc_f, bc_f[i,:])
+        update_param!(fair_instance, :radiative_forcing, :bc_snow_f, bc_snow_f[i,:])
+        update_param!(fair_instance, :radiative_forcing, :bc_aci_f, bc_aci_f[i,:])
+        update_param!(fair_instance, :radiative_forcing, :co_f, co_f[i,:])
+        update_param!(fair_instance, :radiative_forcing, :co_o3_f, co_o3_f[i,:])
+        update_param!(fair_instance, :radiative_forcing, :nh3_f, nh3_f[i,:])
+        update_param!(fair_instance, :radiative_forcing, :nmvoc_f, nmvoc_f[i,:])
+        update_param!(fair_instance, :radiative_forcing, :nmvoc_o3_f, nmvoc_o3_f[i,:])
+        update_param!(fair_instance, :radiative_forcing, :nox_f, nox_f[i,:])
+        update_param!(fair_instance, :radiative_forcing, :nox_o3_f, nox_o3_f[i,:])
+        update_param!(fair_instance, :radiative_forcing, :nox_avi_f, nox_avi_f[i,:])
+        update_param!(fair_instance, :radiative_forcing, :nox_avi_contrails_f, nox_avi_contrails_f[i,:])
+        update_param!(fair_instance, :radiative_forcing, :oc_f, oc_f[i,:])
+        update_param!(fair_instance, :radiative_forcing, :oc_aci_f, oc_aci_f[i,:])
+        update_param!(fair_instance, :radiative_forcing, :so2_f, so2_f[i,:])
+        update_param!(fair_instance, :radiative_forcing, :so2_aci_f, so2_aci_f[i,:])
+        update_param!(fair_instance, :radiative_forcing, :solar_f, exogenous_forcing_params[i, :solar])
+        update_param!(fair_instance, :radiative_forcing, :landuse_f, exogenous_forcing_params[i, :land_use])
+        update_param!(fair_instance, :radiative_forcing, :volcanic_f, exogenous_forcing_params[i, :volcanic])
 
-            # ---- Global Temperature Anomaly ---- #
-            update_param!(fair_instance, :temperature, :decay_factor, thermal_decay_factors[i,:])
-            update_param!(fair_instance, :temperature, :q, Array(thermal_params[i,[:q1,:q2,:q3]]))
-            #update_param!(fair_instance, :temperature, :Tj_0, vec(Array(init_thermal_vals[:,[:thermal_box_1,:thermal_box_2,:thermal_box_3]])))
-            #update_param!(fair_instance, :temperature, :T_0, init_thermal_vals.global_temp_anomaly[1])
-
-            # ---- Carbon Cycle ---- #
-            update_param!(fair_instance, :co2_cycle, :r0_co2, co2_p.r0[i])
-            update_param!(fair_instance, :co2_cycle, :rU_co2, co2_p.rC[i])
-            update_param!(fair_instance, :co2_cycle, :rT_co2, co2_p.rT[i])
-            update_param!(fair_instance, :co2_cycle, :rA_co2, co2_p.rA[i])
-            update_param!(fair_instance, :co2_cycle, :g0_co2, g0_co2[i])
-            update_param!(fair_instance, :co2_cycle, :g1_co2, g1_co2[i])
-            update_param!(fair_instance, :co2_cycle, :a_co2,  co2_a[i,:])
-            update_param!(fair_instance, :co2_cycle, :τ_co2,  co2_τ[i,:])
-            # update_param!(fair_instance, :co2_cycle, :co2_0, co2_init.concentration[1])
-            # update_param!(fair_instance, :co2_cycle, :GU_co2_0, co2_init.cumulative_uptake[1])
-            # update_param!(fair_instance, :co2_cycle, :R0_co2, vec(Array(co2_init[:,[:pool1,:pool2,:pool3,:pool4]])))
-
-            # ---- Methane Cycle ---- #
-            update_param!(fair_instance, :ch4_cycle, :r0_ch4, ch4_p.r0[i])
-            update_param!(fair_instance, :ch4_cycle, :rU_ch4, ch4_p.rC[i])
-            update_param!(fair_instance, :ch4_cycle, :rT_ch4, ch4_p.rT[i])
-            update_param!(fair_instance, :ch4_cycle, :rA_ch4, ch4_p.rA[i])
-            update_param!(fair_instance, :ch4_cycle, :g0_ch4, g0_ch4[i])
-            update_param!(fair_instance, :ch4_cycle, :g1_ch4, g1_ch4[i])
-            update_param!(fair_instance, :ch4_cycle, :a_ch4,  ch4_a[i,:])
-            update_param!(fair_instance, :ch4_cycle, :τ_ch4,  ch4_τ[i,:])
-            # update_param!(fair_instance, :ch4_cycle, :ch4_0, ch4_init.concentration[1])
-            # update_param!(fair_instance, :ch4_cycle, :GU_ch4_0, ch4_init.cumulative_uptake[1])
-            # update_param!(fair_instance, :ch4_cycle, :R0_ch4, vec(Array(ch4_init[:,[:pool1,:pool2,:pool3,:pool4]])))
-
-            # ---- Nitrous Oxide Cycle ---- #
-            update_param!(fair_instance, :n2o_cycle, :r0_n2o, n2o_p.r0[i])
-            update_param!(fair_instance, :n2o_cycle, :rU_n2o, n2o_p.rC[i])
-            update_param!(fair_instance, :n2o_cycle, :rT_n2o, n2o_p.rT[i])
-            update_param!(fair_instance, :n2o_cycle, :rA_n2o, n2o_p.rA[i])
-            update_param!(fair_instance, :n2o_cycle, :g0_n2o, g0_n2o[i])
-            update_param!(fair_instance, :n2o_cycle, :g1_n2o, g1_n2o[i])
-            update_param!(fair_instance, :n2o_cycle, :a_n2o,  n2o_a[i,:])
-            update_param!(fair_instance, :n2o_cycle, :τ_n2o,  n2o_τ[i,:])
-            # update_param!(fair_instance, :n2o_cycle, :n2o_0, n2o_init.concentration[1])
-            # update_param!(fair_instance, :n2o_cycle, :GU_n2o_0, n2o_init.cumulative_uptake[1])
-            # update_param!(fair_instance, :n2o_cycle, :R0_n2o, vec(Array(n2o_init[:,[:pool1,:pool2,:pool3,:pool4]])))
-
-            # ---- Flourinated Gas Cycles ---- #
-            update_param!(fair_instance, :flourinated_cycles, :r0_flourinated, flourinated_r0[:,i])
-            update_param!(fair_instance, :flourinated_cycles, :rU_flourinated, flourinated_rC[:,i])
-            update_param!(fair_instance, :flourinated_cycles, :rT_flourinated, flourinated_rT[:,i])
-            update_param!(fair_instance, :flourinated_cycles, :rA_flourinated, flourinated_rA[:,i])
-            update_param!(fair_instance, :flourinated_cycles, :g0_flourinated, flourinated_g0[:,i])
-            update_param!(fair_instance, :flourinated_cycles, :g1_flourinated, flourinated_g1[:,i])
-            update_param!(fair_instance, :flourinated_cycles, :a_flourinated,  flourinated_a[:,:,i])
-            update_param!(fair_instance, :flourinated_cycles, :τ_flourinated,  flourinated_τ[:,:,i])
-            # update_param!(fair_instance, :flourinated_cycles, :flourinated_0, flourinated_init[:, :concentration])
-            # update_param!(fair_instance, :flourinated_cycles, :GU_flourinated_0, flourinated_init[:, :cumulative_uptake])
-            # update_param!(fair_instance, :flourinated_cycles, :R0_flourinated, Array(flourinated_init[:,[:pool1,:pool2,:pool3,:pool4]]))
-
-            # ---- Montreal Protocol Gas Cycles ---- #
-            update_param!(fair_instance, :montreal_cycles, :r0_montreal, montreal_r0[:,i])
-            update_param!(fair_instance, :montreal_cycles, :rU_montreal, montreal_rC[:,i])
-            update_param!(fair_instance, :montreal_cycles, :rT_montreal, montreal_rT[:,i])
-            update_param!(fair_instance, :montreal_cycles, :rA_montreal, montreal_rA[:,i])
-            update_param!(fair_instance, :montreal_cycles, :g0_montreal, montreal_g0[:,i])
-            update_param!(fair_instance, :montreal_cycles, :g1_montreal, montreal_g1[:,i])
-            update_param!(fair_instance, :montreal_cycles, :a_montreal,  montreal_a[:,:,i])
-            update_param!(fair_instance, :montreal_cycles, :τ_montreal,  montreal_τ[:,:,i])
-            # update_param!(fair_instance, :montreal_cycles, :montreal_0, montreal_init[:, :concentration])
-            # update_param!(fair_instance, :montreal_cycles, :GU_montreal_0, montreal_init[:, :cumulative_uptake])
-            # update_param!(fair_instance, :montreal_cycles, :R0_montreal, Array(montreal_init[:,[:pool1,:pool2,:pool3,:pool4]]))
-
-            # ---- Tropospheric Ozone Precursors, Aerosols, & Reactive Gas Cycles (Aerosol+) ---- #
-            update_param!(fair_instance, :aerosol_plus_cycles, :r0_aerosol_plus, aerosol_plus_r0[:,i])
-            update_param!(fair_instance, :aerosol_plus_cycles, :rU_aerosol_plus, aerosol_plus_rC[:,i])
-            update_param!(fair_instance, :aerosol_plus_cycles, :rT_aerosol_plus, aerosol_plus_rT[:,i])
-            update_param!(fair_instance, :aerosol_plus_cycles, :rA_aerosol_plus, aerosol_plus_rA[:,i])
-            update_param!(fair_instance, :aerosol_plus_cycles, :g0_aerosol_plus, aerosol_plus_g0[:,i])
-            update_param!(fair_instance, :aerosol_plus_cycles, :g1_aerosol_plus, aerosol_plus_g1[:,i])
-            update_param!(fair_instance, :aerosol_plus_cycles, :a_aerosol_plus,  aerosol_plus_a[:,:,i])
-            update_param!(fair_instance, :aerosol_plus_cycles, :τ_aerosol_plus,  aerosol_plus_τ[:,:,i])
-            # update_param!(fair_instance, :aerosol_plus_cycles, :aerosol_plus_0, aerosol_plus_init[:, :concentration])
-            # update_param!(fair_instance, :aerosol_plus_cycles, :GU_aerosol_plus_0, aerosol_plus_init[:, :cumulative_uptake])
-            # update_param!(fair_instance, :aerosol_plus_cycles, :R0_aerosol_plus, Array(aerosol_plus_init[:,[:pool1,:pool2,:pool3,:pool4]]))
-
-            # ---- Radiative Forcing ---- #
-            update_param!(fair_instance, :radiative_forcing, :co2_f, co2_f[i,:])
-            update_param!(fair_instance, :radiative_forcing, :ch4_f, ch4_f[i,:])
-            update_param!(fair_instance, :radiative_forcing, :ch4_o3_f, ch4_o3_f[i,:])
-            update_param!(fair_instance, :radiative_forcing, :ch4_h2o_f, ch4_h2o_f[i,:])
-            update_param!(fair_instance, :radiative_forcing, :n2o_f, n2o_f[i,:])
-            update_param!(fair_instance, :radiative_forcing, :n2o_o3_f, n2o_o3_f[i,:])
-            update_param!(fair_instance, :radiative_forcing, :montreal_f, montreal_f[:,:,i])
-            update_param!(fair_instance, :radiative_forcing, :montreal_ind_f, montreal_ind_f[:,:,i])
-            update_param!(fair_instance, :radiative_forcing, :flourinated_f,flourinated_f[:,:,i])
-            update_param!(fair_instance, :radiative_forcing, :bc_f, bc_f[i,:])
-            update_param!(fair_instance, :radiative_forcing, :bc_snow_f, bc_snow_f[i,:])
-            update_param!(fair_instance, :radiative_forcing, :bc_aci_f, bc_aci_f[i,:])
-            update_param!(fair_instance, :radiative_forcing, :co_f, co_f[i,:])
-            update_param!(fair_instance, :radiative_forcing, :co_o3_f, co_o3_f[i,:])
-            update_param!(fair_instance, :radiative_forcing, :nh3_f, nh3_f[i,:])
-            update_param!(fair_instance, :radiative_forcing, :nmvoc_f, nmvoc_f[i,:])
-            update_param!(fair_instance, :radiative_forcing, :nmvoc_o3_f, nmvoc_o3_f[i,:])
-            update_param!(fair_instance, :radiative_forcing, :nox_f, nox_f[i,:])
-            update_param!(fair_instance, :radiative_forcing, :nox_o3_f, nox_o3_f[i,:])
-            update_param!(fair_instance, :radiative_forcing, :nox_avi_f, nox_avi_f[i,:])
-            update_param!(fair_instance, :radiative_forcing, :nox_avi_contrails_f, nox_avi_contrails_f[i,:])
-            update_param!(fair_instance, :radiative_forcing, :oc_f, oc_f[i,:])
-            update_param!(fair_instance, :radiative_forcing, :oc_aci_f, oc_aci_f[i,:])
-            update_param!(fair_instance, :radiative_forcing, :so2_f, so2_f[i,:])
-            update_param!(fair_instance, :radiative_forcing, :so2_aci_f, so2_aci_f[i,:])
-            update_param!(fair_instance, :radiative_forcing, :solar_f, exogenous_forcing_params[i, :solar])
-            update_param!(fair_instance, :radiative_forcing, :landuse_f, exogenous_forcing_params[i, :land_use])
-            update_param!(fair_instance, :radiative_forcing, :volcanic_f, exogenous_forcing_params[i, :volcanic])
-
-            # --- Set Parameters Common to Multiple Components ---- #
-            update_param!(fair_instance, :shared_co2_pi, co2_p[i, :PI_conc])
-            update_param!(fair_instance, :shared_ch4_pi, ch4_p[i, :PI_conc])
-            update_param!(fair_instance, :shared_n2o_pi, n2o_p[i, :PI_conc])
-            update_param!(fair_instance, :shared_montreal_pi, montreal_pi_conc[:,i])
-            update_param!(fair_instance, :shared_flourinated_pi, flourinated_pi_conc[:,i])
-            update_param!(fair_instance, :shared_aerosol_plus_pi, aerosol_plus_pi_conc[:,i])
-
-            # Run model.
-            run(fair_instance)
-
-            # Store projections.
-            temperatures[:,i] = fair_instance[:temperature, :T] # Global mean surface temperature anomaly (K)
-            rf[:, i] = fair_instance[:radiative_forcing, :total_RF] # Total radiative forcing, with individual components scaled by their respective efficacy (Wm⁻²)
-            co2[:, i] = fair_instance[:co2_cycle, :co2]  # Total atmospheric carbon dioxide concentrations (ppm).
-            ch4[:, i] = fair_instance[:ch4_cycle, :ch4]  # Total atmospheric methane concentrations (ppb)
-            n2o[:, i] = fair_instance[:n2o_cycle, :n2o]  # Total atmospheric nitrous oxide concentrations (ppb)
-
-        end
-
-        # Return temperature and radiative forcing 
-        return Dict(:temperatures => temperatures, :rf => rf, :co2 => co2, :ch4 => ch4, :n2o => n2o)
-        
+        # --- Set Parameters Common to Multiple Components ---- #
+        update_param!(fair_instance, :shared_co2_pi, co2_p[i, :PI_conc])
+        update_param!(fair_instance, :shared_ch4_pi, ch4_p[i, :PI_conc])
+        update_param!(fair_instance, :shared_n2o_pi, n2o_p[i, :PI_conc])
+        update_param!(fair_instance, :shared_montreal_pi, montreal_pi_conc[:,i])
+        update_param!(fair_instance, :shared_flourinated_pi, flourinated_pi_conc[:,i])
+        update_param!(fair_instance, :shared_aerosol_plus_pi, aerosol_plus_pi_conc[:,i])
     end
 
     # Recursively delete the constrained files downloaded
     if delete_downloaded_data
         rm(data_dir, recursive = true)
     end
-    # Return 'fair_monte_carlo' function.
-    return fair_monte_carlo
 
+    # Return 'prepare_instance' function.
+    return prepare_instance
 end
+


### PR DESCRIPTION
My text editor also drops lots of space at the end of lines, so that produces a bunch of erroneous edits. All I do is create a `load_fair_monte_carlo` function, which returns a function which takes the `ModelInstance` and a Monte Carlo index and does all of the `update_param!` calls.

I need this to embed the FaIR model into my model. I'm going to post my FaIR-containing component to the discussion on the forum site here: https://forum.mimiframework.org/t/different-timesteps-or-embedded-model/320/7

The basic structure around this is as follows:
 - My component has a `fair_draw` parameter set to `DiscreteUniform(1, samplesize)` when I'm doing a Monte Carlo.
 - It also has a `prepare_instance` parameter (`Parameter{Function}()`), which is by default set to `(mi, ii) -> nothing`.
 - When we set up the Monte Carlo, we run:
```
prepare_instance = MimiFAIRv2.load_fair_monte_carlo(samplesize; end_year=maximum(dim_keys(model, :time)),
                                                            delete_downloaded_data=false)
        disconnect_param!(model, :FaIRGrounds, :prepare_instance)
        update_param!(model, :FaIRGrounds, :prepare_instance, prepare_instance)
```
 - Then within the component's `init` function, we have:
 ```
        if pp.fair_draw != 0
            pp.prepare_instance(pp.fairmi, pp.fair_draw)
        end
```